### PR TITLE
chore: fix test script to point to real (persistent) release file

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [16.x, 20.x]
+        node-version: [18.x, 20.x]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 20.x]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Update npm
-        run: npm install -g npm@8.3.1
+        run: npm install -g npm@10.7.0
       - name: Install Dependencies
         run: npm install
       - name: Test

--- a/test.sh
+++ b/test.sh
@@ -7,11 +7,11 @@ FAILED=''
 
 if [ `node -p process.platform` = "linux" ]; then
   mkdir -p tmp && cd tmp && \
-    curl -O "https://mciuploads.s3.amazonaws.com/mongodb-mongo-master/mongo_csfle/enterprise-rhel-80-64-bit-dynamic-required/237b218974e4fc09104c81fe0bb1ba83688d8035/mongo_csfle_v1_dev-6.0.0-alpha-529-g237b218.tgz" && \
-    tar xvzf mongo_csfle_v1_dev-6.0.0-alpha-529-g237b218.tgz && \
-    ../bin/mongodb-crypt-library-version.js lib/mongo_csfle_v1.so > version && \
+    curl -O "https://downloads.mongodb.com/linux/mongo_crypt_shared_v1-linux-x86_64-enterprise-rhel80-7.0.9.tgz" && \
+    tar xvzf mongo_crypt_shared_v1-linux-x86_64-enterprise-rhel80-7.0.9.tgz && \
+    ../bin/mongodb-crypt-library-version.js lib/mongo_crypt_v1.so > version && \
     cat version && \
-    grep -Fq 'mongo_csfle_v1-dev-6.0.0-alpha-529-g237b218 (0x0000000006000000)' version && \
+    grep -Fq 'mongo_crypt_v1-dev-7.0.9 (0x0007000000090000)' version && \
   cd .. && rm -rf tmp || FAILED=1
 
   mkdir -p tmp && cd tmp && \
@@ -25,11 +25,11 @@ fi
 
 if [ `node -p process.platform` = "darwin" ]; then
   mkdir -p tmp && cd tmp && \
-    curl -O "https://mciuploads.s3.amazonaws.com/mongodb-mongo-master/mongo_csfle/enterprise-macos/237b218974e4fc09104c81fe0bb1ba83688d8035/mongo_csfle_v1-6.0.0-alpha-529-g237b218.tgz" && \
-    tar xvzf mongo_csfle_v1-6.0.0-alpha-529-g237b218.tgz && \
-    ../bin/mongodb-crypt-library-version.js lib/mongo_csfle_v1.dylib > version && \
+    curl -O "https://downloads.mongodb.com/osx/mongo_crypt_shared_v1-macos-x86_64-enterprise-7.0.9.tgz" && \
+    tar xvzf mongo_crypt_shared_v1-macos-x86_64-enterprise-7.0.9.tgz && \
+    ../bin/mongodb-crypt-library-version.js lib/mongo_crypt_v1.dylib > version && \
     cat version && \
-    grep -Fq 'mongo_csfle_v1-dev-6.0.0-alpha-529-g237b218 (0x0000000006000000)' version && \
+    grep -Fq 'mongo_crypt_v1-dev-7.0.9 (0x0007000000090000)' version && \
   cd .. && rm -rf tmp || FAILED=1
 
   mkdir -p tmp && cd tmp && \
@@ -43,11 +43,11 @@ fi
 
 if [ `node -p process.platform` = "win32" ]; then
   mkdir -p tmp && cd tmp && \
-    curl -O "https://mciuploads.s3.amazonaws.com/mongodb-mongo-master/mongo_csfle/enterprise-windows-required/237b218974e4fc09104c81fe0bb1ba83688d8035/mongo_csfle_v1-6.0.0-alpha-529-g237b218.zip" && \
-    unzip mongo_csfle_v1-6.0.0-alpha-529-g237b218.zip && \
-    ../bin/mongodb-crypt-library-version.js bin/mongo_csfle_v1.dll > version && \
+    curl -O "https://downloads.mongodb.com/windows/mongo_crypt_shared_v1-windows-x86_64-enterprise-7.0.9.zip" && \
+    unzip mongo_crypt_shared_v1-windows-x86_64-enterprise-7.0.9.zip && \
+    ../bin/mongodb-crypt-library-version.js bin/mongo_crypt_v1.dll > version && \
     cat version && \
-    grep -Fq 'mongo_csfle_v1-dev-6.0.0-alpha-529-g237b218 (0x0000000006000000)' version && \
+    grep -Fq 'mongo_crypt_v1-dev-7.0.9 (0x0007000000090000)' version && \
   cd .. && rm -rf tmp || FAILED=1
 
   mkdir -p tmp && cd tmp && \

--- a/test.sh
+++ b/test.sh
@@ -4,19 +4,20 @@ set -x
 
 rm -rf tmp
 FAILED=''
+ARCH=$(uname -m)
 
 if [ `node -p process.platform` = "linux" ]; then
   mkdir -p tmp && cd tmp && \
-    curl -O "https://downloads.mongodb.com/linux/mongo_crypt_shared_v1-linux-x86_64-enterprise-rhel80-7.0.9.tgz" && \
-    tar xvzf mongo_crypt_shared_v1-linux-x86_64-enterprise-rhel80-7.0.9.tgz && \
+    curl -O "https://downloads.mongodb.com/linux/mongo_crypt_shared_v1-linux-$ARCH-enterprise-rhel80-7.0.9.tgz" && \
+    tar xvzf mongo_crypt_shared_v1-linux-$ARCH-enterprise-rhel80-7.0.9.tgz && \
     ../bin/mongodb-crypt-library-version.js lib/mongo_crypt_v1.so > version && \
     cat version && \
     grep -Fq 'mongo_crypt_v1-dev-7.0.9 (0x0007000000090000)' version && \
   cd .. && rm -rf tmp || FAILED=1
 
   mkdir -p tmp && cd tmp && \
-    curl -O "https://downloads.mongodb.com/linux/mongo_csfle_v1-linux-x86_64-enterprise-ubuntu2004-5.3.0-rc3.tgz" && \
-    tar xvzf mongo_csfle_v1-linux-x86_64-enterprise-ubuntu2004-5.3.0-rc3.tgz && \
+    curl -O "https://downloads.mongodb.com/linux/mongo_csfle_v1-linux-$ARCH-enterprise-ubuntu2004-5.3.0-rc3.tgz" && \
+    tar xvzf mongo_csfle_v1-linux-$ARCH-enterprise-ubuntu2004-5.3.0-rc3.tgz && \
     ../bin/mongodb-crypt-library-version.js lib/mongo_csfle_v1.so > version && \
     cat version && \
     grep -Fq 'mongo_crypt_v1-unknown (0x0000000000000000)' version && \
@@ -25,16 +26,16 @@ fi
 
 if [ `node -p process.platform` = "darwin" ]; then
   mkdir -p tmp && cd tmp && \
-    curl -O "https://downloads.mongodb.com/osx/mongo_crypt_shared_v1-macos-x86_64-enterprise-7.0.9.tgz" && \
-    tar xvzf mongo_crypt_shared_v1-macos-x86_64-enterprise-7.0.9.tgz && \
+    curl -O "https://downloads.mongodb.com/osx/mongo_crypt_shared_v1-macos-$ARCH-enterprise-7.0.9.tgz" && \
+    tar xvzf mongo_crypt_shared_v1-macos-$ARCH-enterprise-7.0.9.tgz && \
     ../bin/mongodb-crypt-library-version.js lib/mongo_crypt_v1.dylib > version && \
     cat version && \
     grep -Fq 'mongo_crypt_v1-dev-7.0.9 (0x0007000000090000)' version && \
   cd .. && rm -rf tmp || FAILED=1
 
   mkdir -p tmp && cd tmp && \
-    curl -O "https://downloads.mongodb.com/osx/mongo_csfle_v1-macos-x86_64-enterprise-5.3.0-rc3.tgz" && \
-    tar xvzf mongo_csfle_v1-macos-x86_64-enterprise-5.3.0-rc3.tgz && \
+    curl -O "https://downloads.mongodb.com/osx/mongo_csfle_v1-macos-$ARCH-enterprise-5.3.0-rc3.tgz" && \
+    tar xvzf mongo_csfle_v1-macos-$ARCH-enterprise-5.3.0-rc3.tgz && \
     ../bin/mongodb-crypt-library-version.js lib/mongo_csfle_v1.dylib > version && \
     cat version && \
     grep -Fq 'mongo_crypt_v1-unknown (0x0000000000000000)' version && \
@@ -43,16 +44,16 @@ fi
 
 if [ `node -p process.platform` = "win32" ]; then
   mkdir -p tmp && cd tmp && \
-    curl -O "https://downloads.mongodb.com/windows/mongo_crypt_shared_v1-windows-x86_64-enterprise-7.0.9.zip" && \
-    unzip mongo_crypt_shared_v1-windows-x86_64-enterprise-7.0.9.zip && \
+    curl -O "https://downloads.mongodb.com/windows/mongo_crypt_shared_v1-windows-$ARCH-enterprise-7.0.9.zip" && \
+    unzip mongo_crypt_shared_v1-windows-$ARCH-enterprise-7.0.9.zip && \
     ../bin/mongodb-crypt-library-version.js bin/mongo_crypt_v1.dll > version && \
     cat version && \
     grep -Fq 'mongo_crypt_v1-dev-7.0.9 (0x0007000000090000)' version && \
   cd .. && rm -rf tmp || FAILED=1
 
   mkdir -p tmp && cd tmp && \
-    curl -O "https://downloads.mongodb.com/windows/mongo_csfle_v1-windows-x86_64-enterprise-5.3.0-rc3.zip" && \
-    unzip mongo_csfle_v1-windows-x86_64-enterprise-5.3.0-rc3.zip && \
+    curl -O "https://downloads.mongodb.com/windows/mongo_csfle_v1-windows-$ARCH-enterprise-5.3.0-rc3.zip" && \
+    unzip mongo_csfle_v1-windows-$ARCH-enterprise-5.3.0-rc3.zip && \
     ../bin/mongodb-crypt-library-version.js bin/mongo_csfle_v1.dll > version && \
     cat version && \
     grep -Fq 'mongo_crypt_v1-unknown (0x0000000000000000)' version && \

--- a/test.sh
+++ b/test.sh
@@ -34,11 +34,11 @@ if [ `node -p process.platform` = "darwin" ]; then
   cd .. && rm -rf tmp || FAILED=1
 
   mkdir -p tmp && cd tmp && \
-    curl -O "https://downloads.mongodb.com/osx/mongo_csfle_v1-macos-$ARCH-enterprise-5.3.0-rc3.tgz" && \
-    tar xvzf mongo_csfle_v1-macos-$ARCH-enterprise-5.3.0-rc3.tgz && \
-    ../bin/mongodb-crypt-library-version.js lib/mongo_csfle_v1.dylib > version && \
+    curl -O "https://downloads.mongodb.com/osx/mongo_crypt_shared_v1-macos-$ARCH-enterprise-8.0.0-rc4.tgz" && \
+    tar xvzf mongo_crypt_shared_v1-macos-$ARCH-enterprise-8.0.0-rc4.tgz && \
+    ../bin/mongodb-crypt-library-version.js lib/mongo_crypt_v1.dylib > version && \
     cat version && \
-    grep -Fq 'mongo_crypt_v1-unknown (0x0000000000000000)' version && \
+    grep -Fq 'mongo_crypt_v1-dev-8.0.0-rc4 (0x0008000000000000)' version && \
   cd .. && rm -rf tmp || FAILED=1
 fi
 


### PR DESCRIPTION
This test script was written when releases with the changed `crypt_shared` naming did not exist yet. Now that they do and the alpha release that the tests pointed to are no longer available, update them to point to a real (rc) release.